### PR TITLE
Fixed Syntax error's

### DIFF
--- a/Asterisk/CLI.py
+++ b/Asterisk/CLI.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
 
-'''
-Asterisk/CLI.py: Command-line wrapper around the Asterisk Manager API.
-'''
-
-__author__ = 'David M. Wilson <dw@autosols.com>'
-__id__ = '$Id$'
-
 from __future__ import absolute_import
 import inspect
 import os

--- a/Asterisk/Config.py
+++ b/Asterisk/Config.py
@@ -1,7 +1,3 @@
-'''
-Asterisk/Config.py: filesystem configuration reader.
-'''
-
 from __future__ import absolute_import
 import ConfigParser
 import os

--- a/Asterisk/Logging.py
+++ b/Asterisk/Logging.py
@@ -1,10 +1,3 @@
-'''
-Asterisk/Logging.py: extensions to the Python 2.3 logging module.
-'''
-
-__author__ = 'David Wilson'
-__Id__ = '$Id$'
-
 from __future__ import absolute_import
 import logging
 

--- a/Asterisk/Manager.py
+++ b/Asterisk/Manager.py
@@ -1,10 +1,3 @@
-'''
-Asterisk Manager and Channel objects.
-'''
-
-__author__ = 'David Wilson'
-__id__ = '$Id$'
-
 from __future__ import absolute_import
 import datetime
 import errno

--- a/Asterisk/Util.py
+++ b/Asterisk/Util.py
@@ -1,10 +1,3 @@
-'''
-Asterisk/Util.py: utility classes.
-'''
-
-__author__ = 'David Wilson'
-__Id__ = '$Id$'
-
 from __future__ import absolute_import
 import copy
 import sys

--- a/THANKS
+++ b/THANKS
@@ -18,4 +18,5 @@ have contributed to keeping py-Asterisk alive:
     Salim Fadhley
     Nick Knight
     Jacek Ziolkowski
+    Aiden Andrews-McDermott
 


### PR DESCRIPTION
On python 2.7.6, when trying import from Asterisk import Manager the following error kept getting thrown.

from Asterisk import Manager
Traceback (most recent call last):
File "", line 1, in 
File "/usr/local/lib/python2.7/dist-packages/Asterisk/Manager.py", line 8
from future import absolute_import
SyntaxError: from future imports must occur at the beginning of the file

Tested removing the information above this line (original Authors name) it seem's to have worked.

Have closed issue report https://github.com/jeansch/py-asterisk/issues/4 which is my issue report before i had chance to see if i could fix it.