### PR TITLE
DBGet returns Val not Value

### DIFF
--- a/Asterisk/Manager.py
+++ b/Asterisk/Manager.py
@@ -606,7 +606,7 @@ class CoreActions(object):  # pylint: disable=R0904
             return str(e)
         if response.get('Response') == 'Success':
             packet = self._read_packet()
-        return packet.get('Value')
+        return packet.get('Val')
 
     def DBPut(self, family, key, value):
         'Store a value in the Asterisk database'


### PR DESCRIPTION
The DBGet command returns the requested value in the 'Val' parameter,
not in 'Value'.

Checked in the source of certified-asterisk-1.8.28-cert5
and asterisk-13.7.2.

From asterisk main/db.c:

                astman_append(s, "Event: DBGetResponse\r\n"
                                "Family: %s\r\n"
                                "Key: %s\r\n"
                                "Val: %s\r\n"
                                "%s"
                                "\r\n",
