### PR TITLE
Fix for extra newlines in some SMS messages

### DIFF
--- a/Asterisk/Manager.py
+++ b/Asterisk/Manager.py
@@ -343,8 +343,13 @@ class BaseManager(Asterisk.Logging.InstanceLogger):
 
             if not line:
                 if not packet:
-                    raise GoneAwayError(
-                        'Asterisk Manager connection has gone away.')
+                    try:
+                        self.Ping()
+                    except:
+                        raise GoneAwayError(
+                            'Asterisk Manager connection has gone away.')
+                    else:
+                        continue
 
                 self.log.packet('_read_packet: %r', packet)
 


### PR DESCRIPTION
Some SMS messages have an extra '\r\n' line.  This extra line kills the connection to the Asterisk Manager because _read_packet() raises an exception if it receives a blank line.  

This fix checks the connection first when receiving an empty line before killing it.  If Ping() fails, it raises an exception which then triggers the exception that the Asterisk Manager has gone away.