### PR TITLE
Python3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+/.project
+/.pydevproject
+/.settings

--- a/Asterisk/Manager.py
+++ b/Asterisk/Manager.py
@@ -333,7 +333,7 @@ class BaseManager(Asterisk.Logging.InstanceLogger):
         packet = Asterisk.Util.AttributeDict()
         self.log.debug('In _read_packet().')
         while True:
-            line = self.file.readline().rstrip()
+            line = self.file.readline().decode('utf8').rstrip()
             self.log.io('_read_packet: recv %r', line)
 
             if not line:


### PR DESCRIPTION
Hi,
there is a missing .decode(). It needs to run under python3.

ps: sorry about the gitignore midification. as i believe its harmless.