### PR TITLE
Add message to SubscriptionError exception

### DIFF
--- a/Asterisk/Util.py
+++ b/Asterisk/Util.py
@@ -87,7 +87,7 @@ class EventCollection(Logging.InstanceLogger):
             subscriptions = self.subscriptions[name]
 
         if handler in subscriptions:
-            raise SubscriptionError  # pylint: disable=W0710
+            raise SubscriptionError("Duplicated subscription at event %r", (name))  # pylint: disable=W0710
 
         subscriptions.append(handler)
 


### PR DESCRIPTION
When raises SubcriptionError exception another error it's triggered because error message paramenter is missing

Example
```
~$ ipython
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from Asterisk.Util import SubscriptionError

In [2]: raise SubscriptionError
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-d76b471ae3a5> in <module>
----> 1 raise SubscriptionError

TypeError: __init__() missing 1 required positional argument: 'error'

```